### PR TITLE
Fix name in bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "bs-react-simple-maps",
+  "name": "bs-simple-maps",
   "reason": {
     "react-jsx": 2
   },


### PR DESCRIPTION
The name in bsconfig.json must match the one in package.json, otherwise bsb will use incorrect paths when using it as a library.